### PR TITLE
Disable text input and move toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ _Usage examples are based on a project created with [Angular CLI](https://github
 
 Options can be passed to `<ng2-datepicker>` component via property bindings.
 
-For input `[options]` please see [this](https://github.com/jkuri/ng2-datepicker/blob/master/src/classes/datepicker-options.class.ts).
+For input `[options]` please see [this](https://github.com/jkuri/ng2-datepicker/blob/master/src/components/ng2-datepicker.component.ts#L33-L40).
 
 ## Events
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-datepicker",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Angular2 Datepicker",
   "main": "ng2-datepicker.js",
   "typings": "ng2-datepicker.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-datepicker",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Angular2 Datepicker",
   "main": "ng2-datepicker.js",
   "typings": "ng2-datepicker.d.ts",

--- a/src/components/ng2-datepicker.component.ts
+++ b/src/components/ng2-datepicker.component.ts
@@ -83,9 +83,9 @@ export const CALENDAR_VALUE_ACCESSOR: any = {
   selector: 'ng2-datepicker',
   template: `
   <div class="datepicker-container u-is-unselectable">
-    <div class="datepicker-input-container">
-      <input type="text" class="datepicker-input" [(ngModel)]="date.formatted">
-      <div class="datepicker-input-icon" (click)="toggle()">
+    <div (click)="toggle()" class="datepicker-input-container">
+      <input disabled type="text" class="datepicker-input" [value]="date.formatted">
+      <div class="datepicker-input-icon">
         <i class="ion-ios-calendar-outline"></i>
       </div>
     </div>

--- a/src/components/ng2-datepicker.component.ts
+++ b/src/components/ng2-datepicker.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Inject, OnInit, forwardRef, Input, Output, EventEmitter, Provider } from '@angular/core';
+import { Component, ElementRef, Inject, OnInit, forwardRef, Input, Output, EventEmitter } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { SlimScrollOptions } from 'ng2-slimscroll/ng2-slimscroll';
 import * as moment from 'moment';


### PR DESCRIPTION
Two way data binding on the text input did not work out for us as we needed this field to be tied to the form control. A user was able to type into this field without triggering a change to the control.

Quick fix was to disable the input, make in single direction bound and move the toggle to the whole container