### PR TITLE
This is a fix for minDate when used on its own

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,6 +11,8 @@ export class AppComponent {
   options: DatePickerOptions;
 
   constructor() {
-    this.options = new DatePickerOptions();
+    this.options = new DatePickerOptions({
+      minDate: new Date()
+    });
   }
 }

--- a/src/ng2-datepicker/ng2-datepicker.component.ts
+++ b/src/ng2-datepicker/ng2-datepicker.component.ts
@@ -313,8 +313,8 @@ export class DatePickerComponent implements ControlValueAccessor, OnInit {
   }
 
   generateYears() {
-    const date: moment.Moment = this.minDate || Moment().year(Moment().year() - 40);
-    const toDate: moment.Moment = this.maxDate || Moment().year(Moment().year() + 40);
+    const date: moment.Moment = moment(this.minDate) || Moment().year(Moment().year() - 40);
+    const toDate: moment.Moment = moment(this.maxDate) || Moment().year(Moment().year() + 40);
     const years = toDate.year() - date.year();
 
     for (let i = 0; i < years; i++) {


### PR DESCRIPTION
See issue #198, this change fixes the bug when using the minDate option.

The cause is the generateYears() method, which increments the minDate value as it loops through the years. The fix is to create a method-scoped instance of the minDate object. The same approach has been applied to the maxDate variable too.