### PR TITLE
Datepicker improvements

### DIFF
--- a/src/ng-datepicker/ng-datepicker.component.html
+++ b/src/ng-datepicker/ng-datepicker.component.html
@@ -1,5 +1,5 @@
 <div class="ngx-datepicker-container">
-  <input type="text" class="ngx-datepicker-input" [(ngModel)]="displayValue" readonly (click)="toggle()">
+  <input type="text" *ngIf="!headless" class="ngx-datepicker-input" [(ngModel)]="displayValue" readonly (click)="toggle()">
   <div class="ngx-datepicker-calendar-container" *ngIf="isOpened">
     <div class="topbar-container">
       <svg width="7px" height="10px" viewBox="0 0 7 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" (click)="prevMonth()">

--- a/src/ng-datepicker/ng-datepicker.component.html
+++ b/src/ng-datepicker/ng-datepicker.component.html
@@ -1,5 +1,6 @@
 <div class="ngx-datepicker-container">
   <input type="text" *ngIf="!headless" class="ngx-datepicker-input" [(ngModel)]="displayValue" readonly (click)="toggle()">
+  <ng-content></ng-content>
   <div class="ngx-datepicker-calendar-container" *ngIf="isOpened">
     <div class="topbar-container">
       <svg width="7px" height="10px" viewBox="0 0 7 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" (click)="prevMonth()">

--- a/src/ng-datepicker/ng-datepicker.component.ts
+++ b/src/ng-datepicker/ng-datepicker.component.ts
@@ -41,6 +41,11 @@ export interface DatepickerOptions {
 export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnChanges {
   @Input() options: DatepickerOptions;
 
+  /**
+   * Disable datepicker's input
+   */
+  @Input() headless = false;
+
   isOpened: boolean;
   innerValue: Date;
   displayValue: string;
@@ -227,6 +232,11 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
     }
 
     const input = this.elementRef.nativeElement.querySelector('.ngx-datepicker-input');
+
+    if (input == null) {
+      return;
+    }
+
     if (e.target === input || input.contains(<any>e.target)) {
       return;
     }

--- a/src/ng-datepicker/ng-datepicker.component.ts
+++ b/src/ng-datepicker/ng-datepicker.component.ts
@@ -46,7 +46,11 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
    */
   @Input() headless = false;
 
-  isOpened: boolean;
+  /**
+   * Set datepicker's visibility state
+   */
+  @Input() isOpened = false;
+
   innerValue: Date;
   displayValue: string;
   displayFormat: string;


### PR DESCRIPTION
* Allow hiding input inside the datepicker component using `headless` property
* Mark `isOpened` as property to allow to set datepicker status outside
* Allow embedding nested content inside the datepicker using `<ng-content>`