### PR TITLE
Bar Title If Empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,14 @@ options: DatepickerOptions = {
   firstCalendarDay: 0, // 0 - Sunday, 1 - Monday
   locale: frLocale,
   minDate: new Date(Date.now()), // Minimal selectable date
-  maxDate: new Date(Date.now())  // Maximal selectable date
+  maxDate: new Date(Date.now()),  // Maximal selectable date
+  barTitleIfEmpty: 'Click to select a date'
 };
 ```
 
 For available `format` options check out [here](https://date-fns.org/docs/format).
+
+In case you want to initialize with an empty value, just assign null to the model attribute you're storing the date and you can customize the message in the bar with the property `barTitleIfEmpty`.
 
 ## Run Included Demo
 

--- a/src/ng-datepicker/ng-datepicker.component.ts
+++ b/src/ng-datepicker/ng-datepicker.component.ts
@@ -26,6 +26,7 @@ export interface DatepickerOptions {
   maxYear?: number; // default: current year + 30
   displayFormat?: string; // default: 'MMM D[,] YYYY'
   barTitleFormat?: string; // default: 'MMMM YYYY'
+  barTitleIfEmpty?: string;
   firstCalendarDay?: number; // 0 = Sunday (default), 1 = Monday, ..
   locale?: object;
   minDate?: Date;
@@ -74,6 +75,7 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
   date: Date;
   barTitle: string;
   barTitleFormat: string;
+  barTitleIfEmpty: string;
   minYear: number;
   maxYear: number;
   firstCalendarDay: number;
@@ -146,6 +148,7 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
     this.maxYear = this.options && this.options.maxYear || getYear(today) + 30;
     this.displayFormat = this.options && this.options.displayFormat || 'MMM D[,] YYYY';
     this.barTitleFormat = this.options && this.options.barTitleFormat || 'MMMM YYYY';
+    this.barTitleIfEmpty = this.options && this.options.barTitleIfEmpty || 'Click to select a date';
     this.firstCalendarDay = this.options && this.options.firstCalendarDay || 0;
     this.locale = this.options && { locale: this.options.locale } || {};
   }
@@ -230,7 +233,7 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
     }
 
     this.displayValue = this.innerValue ? format(this.innerValue, this.displayFormat, this.locale) : '';
-    this.barTitle = format(start, this.barTitleFormat, this.locale);
+    this.barTitle =  this.innerValue ? format(start, this.barTitleFormat, this.locale) : this.barTitleIfEmpty;
   }
 
   initYears(): void {


### PR DESCRIPTION
Due to this comment:

https://github.com/bleenco/ng2-datepicker/issues/12#issuecomment-356715348

It would be nice to allow the user to specify a bar title format if he/she wants to initialize with an empty field. The fix was pretty simple.

<img width="892" alt="screen shot 2018-01-13 at 10 21 10 pm" src="https://user-images.githubusercontent.com/5366444/34912890-78c53160-f8b2-11e7-8b4c-b351c30b4132.png">

Please review it @jkuri and let me know any feedback that you want to address with this change.

