### PR TITLE
Ability to set format for day names from options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ options: DatepickerOptions = {
   maxYear: 2030,
   displayFormat: 'MMM D[,] YYYY',
   barTitleFormat: 'MMMM YYYY',
+  dayNamesFormat: 'dd',
   firstCalendarDay: 0, // 0 - Sunday, 1 - Monday
   locale: frLocale,
   minDate: new Date(Date.now()), // Minimal selectable date

--- a/src/ng-datepicker/component/ng-datepicker.component.ts
+++ b/src/ng-datepicker/component/ng-datepicker.component.ts
@@ -26,6 +26,7 @@ export interface DatepickerOptions {
   maxYear?: number; // default: current year + 30
   displayFormat?: string; // default: 'MMM D[,] YYYY'
   barTitleFormat?: string; // default: 'MMMM YYYY'
+  dayNamesFormat?: string; // default 'ddd'
   barTitleIfEmpty?: string;
   firstCalendarDay?: number; // 0 = Sunday (default), 1 = Monday, ..
   locale?: object;
@@ -82,6 +83,7 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
   view: string;
   years: { year: number; isThisYear: boolean }[];
   dayNames: string[];
+  dayNamesFormat: string;
   scrollOptions: ISlimScrollOptions;
   days: {
     date: Date;
@@ -148,6 +150,7 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
     this.maxYear = this.options && this.options.maxYear || getYear(today) + 30;
     this.displayFormat = this.options && this.options.displayFormat || 'MMM D[,] YYYY';
     this.barTitleFormat = this.options && this.options.barTitleFormat || 'MMMM YYYY';
+    this.dayNamesFormat = this.options && this.options.dayNamesFormat || 'ddd';
     this.barTitleIfEmpty = this.options && this.options.barTitleIfEmpty || 'Click to select a date';
     this.firstCalendarDay = this.options && this.options.firstCalendarDay || 0;
     this.locale = this.options && { locale: this.options.locale } || {};
@@ -248,7 +251,7 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
     const start = this.firstCalendarDay;
     for (let i = start; i <= 6 + start; i++) {
       const date = setDay(new Date(), i);
-      this.dayNames.push(format(date, 'ddd', this.locale));
+      this.dayNames.push(format(date, this.dayNamesFormat, this.locale));
     }
   }
 


### PR DESCRIPTION
Add ability to change the format for day names

Example:

Default format ('ddd'):
![1](https://user-images.githubusercontent.com/5096148/35330690-6dddd7c8-0115-11e8-8ed3-5cb272b3508b.PNG)

Custom format ('dd'):
![2](https://user-images.githubusercontent.com/5096148/35330691-6dfb0b40-0115-11e8-8b9f-6041b60964dd.PNG)


