### PR TITLE
Improvement in UX when no date is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ options: DatepickerOptions = {
   locale: frLocale,
   minDate: new Date(Date.now()), // Minimal selectable date
   maxDate: new Date(Date.now()),  // Maximal selectable date
-  barTitleIfEmpty: 'Click to select a date'
+  barTitleIfEmpty: 'Click to select a date',
+  placeholder: 'Enter Date'
 };
 ```
 

--- a/src/components/app-home/app-home.component.ts
+++ b/src/components/app-home/app-home.component.ts
@@ -13,6 +13,6 @@ export class AppHomeComponent {
     locale: enLocale
   };
   constructor() {
-    this.date = new Date();
+    this.date = null;
   }
 }

--- a/src/ng-datepicker/component/ng-datepicker.component.html
+++ b/src/ng-datepicker/component/ng-datepicker.component.html
@@ -1,5 +1,5 @@
 <div class="ngx-datepicker-container">
-  <input type="text" *ngIf="!headless" class="ngx-datepicker-input" [(ngModel)]="displayValue" readonly (click)="toggle()">
+  <input type="text" *ngIf="!headless" class="ngx-datepicker-input" [(ngModel)]="displayValue" placeholder="{{ placeholder }}" readonly (click)="toggle()">
   <ng-content></ng-content>
   <div class="ngx-datepicker-calendar-container ngx-datepicker-position-{{position}}" *ngIf="isOpened">
     <div class="topbar-container">

--- a/src/ng-datepicker/component/ng-datepicker.component.html
+++ b/src/ng-datepicker/component/ng-datepicker.component.html
@@ -3,41 +3,44 @@
   <ng-content></ng-content>
   <div class="ngx-datepicker-calendar-container ngx-datepicker-position-{{position}}" *ngIf="isOpened">
     <div class="topbar-container">
-      <svg width="7px" height="10px" viewBox="0 0 7 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" (click)="prevMonth()">
-        <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-          <g transform="translate(-923.000000, -1882.000000)" fill="#CED0DA">
-            <g transform="translate(80.000000, 1361.000000)">
-              <g transform="translate(0.000000, 430.000000)">
-                <g transform="translate(825.000000, 0.000000)">
-                  <g transform="translate(0.000000, 72.000000)">
-                    <g transform="translate(18.000000, 15.000000)">
-                      <polygon id="Back" points="6.015 4 0 9.013 6.015 14.025"></polygon>
+      <div class="month-year-toggler">
+        <svg width="7px" height="10px" viewBox="0 0 7 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" (click)="prevMonth()">
+          <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+            <g transform="translate(-923.000000, -1882.000000)" fill="#CED0DA">
+              <g transform="translate(80.000000, 1361.000000)">
+                <g transform="translate(0.000000, 430.000000)">
+                  <g transform="translate(825.000000, 0.000000)">
+                    <g transform="translate(0.000000, 72.000000)">
+                      <g transform="translate(18.000000, 15.000000)">
+                        <polygon id="Back" points="6.015 4 0 9.013 6.015 14.025"></polygon>
+                      </g>
                     </g>
                   </g>
                 </g>
               </g>
             </g>
           </g>
-        </g>
-      </svg>
-      <span class="topbar-title" (click)="toggleView()">{{ barTitle }}</span>
-      <svg width="7px" height="10px" viewBox="0 0 6 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" (click)="nextMonth()">
-        <g id="Source-Sans---UI-Elements-Kit" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-          <g id="White-Layout" transform="translate(-1182.000000, -1882.000000)" fill="#CED0DA">
-            <g id="Dropdowns-&amp;-Selector" transform="translate(80.000000, 1361.000000)">
-              <g id="Dropdowns" transform="translate(0.000000, 430.000000)">
-                <g id="Calendar" transform="translate(825.000000, 0.000000)">
-                  <g transform="translate(0.000000, 72.000000)" id="Top-Bar-Nav">
-                    <g transform="translate(18.000000, 15.000000)">
-                      <polygon id="Forward" transform="translate(262.007500, 9.012500) scale(-1, 1) translate(-262.007500, -9.012500) " points="265.015 4 259 9.013 265.015 14.025"></polygon>
+        </svg>
+        <span class="topbar-title" (click)="toggleView()">{{ selectedYear }}</span>
+        <svg width="7px" height="10px" viewBox="0 0 6 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" (click)="nextMonth()">
+          <g id="Source-Sans---UI-Elements-Kit" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+            <g id="White-Layout" transform="translate(-1182.000000, -1882.000000)" fill="#CED0DA">
+              <g id="Dropdowns-&amp;-Selector" transform="translate(80.000000, 1361.000000)">
+                <g id="Dropdowns" transform="translate(0.000000, 430.000000)">
+                  <g id="Calendar" transform="translate(825.000000, 0.000000)">
+                    <g transform="translate(0.000000, 72.000000)" id="Top-Bar-Nav">
+                      <g transform="translate(18.000000, 15.000000)">
+                        <polygon id="Forward" transform="translate(262.007500, 9.012500) scale(-1, 1) translate(-262.007500, -9.012500) " points="265.015 4 259 9.013 265.015 14.025"></polygon>
+                      </g>
                     </g>
                   </g>
                 </g>
               </g>
             </g>
           </g>
-        </g>
-      </svg>
+        </svg>
+      </div>
+      <p class="topbar-title year-selector-title" (click)="toggleView()" *ngIf="view === 'days'">{{ barTitle }}</p>
     </div>
     <div class="main-calendar-container" *ngIf="view === 'days'">
       <div class="main-calendar-day-names">

--- a/src/ng-datepicker/component/ng-datepicker.component.sass
+++ b/src/ng-datepicker/component/ng-datepicker.component.sass
@@ -43,13 +43,15 @@ $color: #1A91EB
 
     .topbar-container
       width: 100%
-      height: 50px
+      height: 70px
       padding: 15px
       border-bottom: 1px solid $border
-      display: flex
-      justify-content: space-between
-      align-items: center
       user-select: none
+
+      .month-year-toggler
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
 
       svg
         cursor: pointer
@@ -62,6 +64,11 @@ $color: #1A91EB
         font-size: 14px
         font-weight: 600
         cursor: pointer
+      
+      .year-selector-title
+        padding-top: 5px;
+        display: flex;
+        justify-content: space-around;
 
     .main-calendar-container
       width: 100%

--- a/src/ng-datepicker/component/ng-datepicker.component.ts
+++ b/src/ng-datepicker/component/ng-datepicker.component.ts
@@ -130,6 +130,7 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
     this.setOptions();
     this.initDayNames();
     this.initYears();
+    this.initYear();
 
     // Check if 'position' property is correct
     if (this.positions.indexOf(this.position) === -1) {
@@ -153,7 +154,7 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
     this.displayFormat = this.options && this.options.displayFormat || 'MMM D[,] YYYY';
     this.barTitleFormat = this.options && this.options.barTitleFormat || 'MMMM YYYY';
     this.dayNamesFormat = this.options && this.options.dayNamesFormat || 'ddd';
-    this.barTitleIfEmpty = this.options && this.options.barTitleIfEmpty || 'Click to select a date';
+    this.barTitleIfEmpty = this.options && this.options.barTitleIfEmpty || 'Click to select year';
     this.firstCalendarDay = this.options && this.options.firstCalendarDay || 0;
     this.locale = this.options && { locale: this.options.locale } || {};
     this.placeholder = this.options && this.options.placeholder || 'Enter Date';
@@ -259,6 +260,14 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
       const date = setDay(new Date(), i);
       this.dayNames.push(format(date, this.dayNamesFormat, this.locale));
     }
+  }
+
+  initYear(): void {
+    this.years.forEach((year, index) => {
+      if(year.isThisYear) {
+        this.setYear(index)
+      }
+    })
   }
 
   toggleView(): void {

--- a/src/ng-datepicker/component/ng-datepicker.component.ts
+++ b/src/ng-datepicker/component/ng-datepicker.component.ts
@@ -32,6 +32,7 @@ export interface DatepickerOptions {
   locale?: object;
   minDate?: Date;
   maxDate?: Date;
+  placeholder?: string;
 }
 
 /**
@@ -96,6 +97,7 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
     isSelectable: boolean;
   }[];
   locale: object;
+  placeholder: string;
 
   private onTouchedCallback: () => void = () => { };
   private onChangeCallback: (_: any) => void = () => { };
@@ -154,6 +156,7 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
     this.barTitleIfEmpty = this.options && this.options.barTitleIfEmpty || 'Click to select a date';
     this.firstCalendarDay = this.options && this.options.firstCalendarDay || 0;
     this.locale = this.options && { locale: this.options.locale } || {};
+    this.placeholder = this.options && this.options.placeholder || 'Enter Date';
   }
 
   nextMonth(): void {

--- a/src/ng-datepicker/component/ng-datepicker.component.ts
+++ b/src/ng-datepicker/component/ng-datepicker.component.ts
@@ -98,6 +98,7 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
   }[];
   locale: object;
   placeholder: string;
+  selectedYear: string;
 
   private onTouchedCallback: () => void = () => { };
   private onChangeCallback: (_: any) => void = () => { };
@@ -243,7 +244,8 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
     }
 
     this.displayValue = this.innerValue ? format(this.innerValue, this.displayFormat, this.locale) : '';
-    this.barTitle =  this.innerValue ? format(start, this.barTitleFormat, this.locale) : this.barTitleIfEmpty;
+    this.selectedYear =  format(start, this.barTitleFormat, this.locale);
+    this.barTitle =  this.barTitleIfEmpty;
   }
 
   initYears(): void {
@@ -316,7 +318,7 @@ export class NgDatepickerComponent implements ControlValueAccessor, OnInit, OnCh
     }
 
     const container = this.elementRef.nativeElement.querySelector('.ngx-datepicker-calendar-container');
-    if (container && container !== e.target && !container.contains(<any>e.target) && !(<any>e.target).classList.contains('year-unit')) {
+    if (container && container !== e.target && !container.contains(<any>e.target) && !(<any>e.target).classList.contains('year-unit') && !(<any>e.target).classList.contains('topbar-title')) {
       this.close();
     }
   }


### PR DESCRIPTION
When we don't provide any date, it's very confusing for the user to know which month, or year is selected. Also the calendar is not expanded by default when clicked.
Developers are also left with no option to add any placeholder in case of empty date. 
This pull request addresses all those issues. Hope it helps!