### PR TITLE
bugfix: fixed issues with min max date

### DIFF
--- a/projects/datepicker/src/lib/datepicker.component.ts
+++ b/projects/datepicker/src/lib/datepicker.component.ts
@@ -271,11 +271,11 @@ export class DatepickerComponent implements ControlValueAccessor, OnInit, OnChan
   }
 
   private isDateSelectable(date: Date): boolean {
-    if (this.options.minDate && isBefore(this.options.minDate, date)) {
+    if (this.options.minDate && isBefore(date, this.options.minDate)) {
       return false;
     }
 
-    if (this.options.maxDate && isAfter(this.options.maxDate, date)) {
+    if (this.options.maxDate && isAfter(date, this.options.maxDate)) {
       return false;
     }
 


### PR DESCRIPTION
Min max options are working incorrectly:

If I set

minDate -> 15.06.2021, then it allows to select 01.06-15.06. First argument should be date, not this.options.minDate. Same situation for maxDate.

```
  private isDateSelectable(date: Date): boolean {
    if (this.options.minDate && isBefore(this.options.minDate, date)) {
      return false;    
    }
    if (this.options.maxDate && isAfter(this.options.maxDate, date)) {
      return false;
    }
    return true;
  }
```
This PR fixes it.

Is it fine now?